### PR TITLE
Add Allow-origin-header on 401 response

### DIFF
--- a/cors.conf
+++ b/cors.conf
@@ -133,7 +133,7 @@ add_header X-CORS-Verbose-Service $cors_service_vebose;
 add_header X-CORS-Verbose-Client $cors_client_vebose;
 
 # CORS
-add_header Access-Control-Allow-Origin $cors_allow_origin_value;
+add_header Access-Control-Allow-Origin $cors_allow_origin_value always;
 add_header Access-Control-Allow-Methods $cors_allow_methods_value;
 add_header Access-Control-Allow-Headers $cors_allow_headers_value;
 add_header Access-Control-Expose-Headers $cors_allow_expose_headers_value;


### PR DESCRIPTION
Для примера шлю запрос авторизации и получаю 401 ошибку.
Т.к. нет ключевого слова always (https://nginx.org/ru/docs/http/ngx_http_headers_module.html), то Chrome выкидывает ошибку CORS, хотя логично, что должен выкинуть только ошибку авторизации.

Предлагаю добавить always к заголовку Access-Control-Allow-Origin