### PR TITLE
[+] Expose-Headers shown not only on preflight

### DIFF
--- a/cors.conf
+++ b/cors.conf
@@ -102,13 +102,13 @@ if ($cors_service = '') {
 if ($cors_enabled = 'true') {
 	set $cors_allow_origin_value $cors_allow_origin;
 	set $cors_vary_value $cors_vary;
+	set $cors_allow_expose_headers_value $cors_allow_expose_headers;
 }
 
 # Preflight headers
 if ($cors_preflight = 'true') {
 	set $cors_allow_methods_value $cors_allow_methods;
 	set $cors_allow_headers_value $cors_allow_headers;
-	set $cors_allow_expose_headers_value $cors_allow_expose_headers;
 	set $cors_max_age_value $cors_max_age;
 }
 


### PR DESCRIPTION
Access-Control-Expose-Headers нужно посылать всегда (не только во время preflight) https://developer.mozilla.org/ru/docs/Web/HTTP/Headers/Access-Control-Expose-Headers 