### PR TITLE
[+] Content-Disposition default expose header

### DIFF
--- a/cors.conf
+++ b/cors.conf
@@ -3,7 +3,7 @@
 # $cors_allow_headers — string separated by comma (optional, default: see $cors_allow_headers_default)
 # $cors_allow_headers_force — for 'allow header' without default, string separated by comma (optional)
 # $cors_allow_credentials — "true" or "false" (optional, default: false)
-# $cors_allow_expose_headers — string (optional, default: <<empty>>)
+# $cors_allow_expose_headers — string (optional, default: "Content-Disposition")
 # $cors_vary — string or "false" (optional, default: "Origin")
 # $cors_max_age — number (optional, default: 86400)
 # $cors_verbose - "true" or "false" (optional, default: false)
@@ -14,7 +14,7 @@ set $cors_vary_default 'Origin';
 set $cors_allow_origin $http_origin;
 set $cors_allow_methods_default 'OPTIONS, GET, POST';
 set $cors_allow_headers_default 'DNT, Authorization, Origin, X-Requested-With, X-Host, X-Request-Id, Timing-Allow-Origin, Content-Type, Accept, Content-Range, Range, Keep-Alive, User-Agent, If-Modified-Since, Cache-Control, Content-Type';
-set $cors_allow_expose_headers_default '';
+set $cors_allow_expose_headers_default 'Content-Disposition';
 
 # Default: methods
 if ($cors_allow_methods = '') {


### PR DESCRIPTION
Не могу оценить как это влияет на безопасность и почему Content-Disposition не добавили в список дефолтных хидеров, поэтому предлагаю добавить его тут (а то через swagger-api скачивание файлов не происходит корректно).

Причем там есть все Content-* хидеры, но не сабжа.

https://developer.mozilla.org/ru/docs/Web/HTTP/Headers/Access-Control-Expose-Headers