### PR TITLE
Improve debugging

### DIFF
--- a/cors.conf
+++ b/cors.conf
@@ -9,12 +9,15 @@
 # $cors_verbose - "true" or "false" (optional, default: false)
 # $cors_debug - "true" or "false" (optional, default: false)
 
+
 set $cors_preflight 'false';
 set $cors_vary_default 'Origin';
 set $cors_allow_origin $http_origin;
 set $cors_allow_methods_default 'OPTIONS, GET, POST';
 set $cors_allow_headers_default 'DNT, Authorization, Origin, X-Requested-With, X-Host, X-Request-Id, Timing-Allow-Origin, Content-Type, Accept, Content-Range, Range, Keep-Alive, User-Agent, If-Modified-Since, Cache-Control, Content-Type';
 set $cors_allow_expose_headers_default 'Content-Disposition';
+
+uninitialized_variable_warn off;
 
 # Default: methods
 if ($cors_allow_methods = '') {
@@ -143,39 +146,55 @@ add_header Vary $cors_vary_value always;
 
 # Debug
 if ($cors_debug = 'true') {
-	add_header X-CORS-Debug-Enabled $cors_enabled;
-	add_header X-CORS-Debug-Preflight $cors_preflight;
-	add_header X-CORS-Debug-Service $cors_service;
-	add_header X-CORS-Debug-Client $cors_client;
-	add_header X-CORS-Debug-Path $cors_path;
-	add_header X-CORS-Debug-Http-Origin $http_origin;
-	add_header X-CORS-Debug-Request "$scheme://$host$request_uri";
-	add_header X-CORS-Debug-Request-Method $request_method;
+    set $cors_debug_enabled $cors_enabled;
+    set $cors_debug_preflight $cors_preflight;
+    set $cors_debug_service $cors_service;
+    set $cors_debug_client $cors_client;
+    set $cors_debug_path $cors_path;
+    set $cors_debug_http_origin $http_origin;
+    set $cors_debug_request "$scheme://$host$request_uri";
+    set $cors_debug_request_method $request_method;
+    set $cors_debug_allow_origin $cors_allow_origin;
+    set $cors_debug_allow_methods $cors_allow_methods;
+    set $cors_debug_allow_headers $cors_allow_headers;
+    set $cors_debug_allow_credentials $cors_allow_credentials;
+    set $cors_debug_allow_expose_headers $cors_allow_expose_headers;
+    set $cors_debug_max_age $cors_max_age;
+    set $cors_debug_vary $cors_vary;
 
-	add_header X-CORS-Debug-Var-Origin $cors_allow_origin;
-	add_header X-CORS-Debug-Var-Methods $cors_allow_methods;
-	add_header X-CORS-Debug-Var-Headers $cors_allow_headers;
-	add_header X-CORS-Debug-Var-Credentials $cors_allow_credentials;
-	add_header X-CORS-Debug-Var-Headers $cors_allow_expose_headers;
-	add_header X-CORS-Debug-Var-Max-Age $cors_max_age;
-	add_header X-CORS-Debug-Var-Vary $cors_vary;
-
-	add_header X-CORS-Debug-Hr "---------------------------";
-
-	add_header X-CORS-Debug-Access-Control-Allow-Origin $cors_allow_origin_value;
-	add_header X-CORS-Debug-Access-Control-Allow-Methods $cors_allow_methods_value;
-	add_header X-CORS-Debug-Access-Control-Allow-Headers $cors_allow_headers_value;
-	add_header X-CORS-Debug-Access-Control-Allow-Credentials $cors_allow_credentials_value;
-	add_header X-CORS-Debug-Access-Control-Expose-Headers $cors_allow_expose_headers_value;
-	add_header X-CORS-Debug-Access-Control-Max-Age $cors_max_age_value;
-	add_header X-CORS-Debug-Vary $cors_vary;
-
-	add_header X-CORS-Debug-Hr "---------------------------";
-
-	return 204;
+    set $cors_debug_allow_origin_value $cors_allow_origin_value;
+    set $cors_debug_allow_methods_value $cors_allow_methods_value;
+    set $cors_debug_allow_headers_value $cors_allow_headers_value;
+    set $cors_debug_allow_credentials_value $cors_allow_credentials_value;
+    set $cors_debug_allow_expose_headers_value $cors_allow_expose_headers_value;
+    set $cors_debug_max_age_value $cors_max_age_value;
 }
+
+add_header X-CORS-Debug-Enabled $cors_debug_enabled always;
+add_header X-CORS-Debug-Preflight $cors_debug_preflight always;
+add_header X-CORS-Debug-Service $cors_debug_service always;
+add_header X-CORS-Debug-Client $cors_debug_client always;
+add_header X-CORS-Debug-Path $cors_debug_path always;
+add_header X-CORS-Debug-Http-Origin $cors_debug_http_origin always;
+add_header X-CORS-Debug-Request $cors_debug_request always;
+add_header X-CORS-Debug-Request-Method $cors_debug_request_method always;
+
+add_header X-CORS-Debug-Var-Origin $cors_debug_allow_origin always;
+add_header X-CORS-Debug-Var-Methods $cors_debug_allow_methods always;
+add_header X-CORS-Debug-Var-Headers $cors_debug_allow_headers always;
+add_header X-CORS-Debug-Var-Credentials $cors_debug_allow_credentials always;
+add_header X-CORS-Debug-Var-Headers $cors_debug_allow_expose_headers always;
+add_header X-CORS-Debug-Var-Max-Age $cors_debug_max_age always;
+add_header X-CORS-Debug-Var-Vary $cors_debug_vary always;
+
+add_header X-CORS-Debug-Access-Control-Allow-Origin $cors_debug_allow_origin_value always;
+add_header X-CORS-Debug-Access-Control-Allow-Methods $cors_debug_allow_methods_value always;
+add_header X-CORS-Debug-Access-Control-Allow-Headers $cors_debug_allow_headers_value always;
+add_header X-CORS-Debug-Access-Control-Allow-Credentials $cors_debug_allow_credentials_value always;
+add_header X-CORS-Debug-Access-Control-Expose-Headers $cors_debug_allow_expose_headers_value always;
+add_header X-CORS-Debug-Access-Control-Max-Age $cors_debug_max_age_value always;
 
 # Preflight
 if ($cors_preflight = 'true') {
-	return 204;
+    return 204;
 }


### PR DESCRIPTION
Show debug headers even if CORS is disabled and request returns 4xx.
Makes it much easier to debug when credentials are enabled.